### PR TITLE
chore: address remaining dependabot alerts

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,20 +5,33 @@ var bodyParser = require('body-parser');
 var cookieParser = require('cookie-parser');
 var flash = require('connect-flash');
 var session = require('express-session');
-var ip = require('ip');
 var logger = require('morgan');
 var passport = require('passport');
 var routes = require('./routes/routes');
 require('./database/db');
 var favicon = require('serve-favicon');
 var setUpPassport = require('./utilities/setuppassport');
+var os = require('os');
 // var cors = require('cors');
 var app = express();
 
 app.use(express.static(path.join(__dirname, 'public')));
 app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')));
 
-var addr = ip.address();
+function getLocalIpAddress() {
+  var interfaces = os.networkInterfaces();
+  for (var name in interfaces) {
+    var entries = interfaces[name] || [];
+    for (var i = 0; i < entries.length; i += 1) {
+      if (entries[i].family === 'IPv4' && !entries[i].internal) {
+        return entries[i].address;
+      }
+    }
+  }
+  return '127.0.0.1';
+}
+
+var addr = getLocalIpAddress();
 console.log('IP Address:', addr);
 
 // view engine setup

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,6 @@
         "express": "~5.2.1",
         "express-session": "^1.19.0",
         "http-errors": "~2.0.1",
-        "ip": "^2.0.1",
         "mongoose": "^9.4.1",
         "morgan": "~1.10.1",
         "passport": "^0.7.0",
@@ -643,12 +642,6 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
-    },
-    "node_modules/ip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/ip/-/ip-2.0.1.tgz",
-      "integrity": "sha512-lJUL9imLTNi1ZfXT+DU6rBBdbiKGBuay9B6xGSPVjUeQwaH1RIGqef8RZkUtHioLmSNpPR5M4HVKJGm1j8FWVQ==",
-      "license": "MIT"
     },
     "node_modules/ipaddr.js": {
       "version": "1.9.1",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "express": "~5.2.1",
     "express-session": "^1.19.0",
     "http-errors": "~2.0.1",
-    "ip": "^2.0.1",
     "mongoose": "^9.4.1",
     "morgan": "~1.10.1",
     "passport": "^0.7.0",


### PR DESCRIPTION
## Summary

- Package manager detected: `npm`
- Install result: `success`

## Dependency manifest changes

- Removed vulnerable `ip` from dependencies.

## Lockfile changes

- Refreshed `package-lock.json`

## Peer dependency warnings or conflicts

- none

## Source files changed beyond manifests/lockfiles

- `app.js` now derives the local IPv4 address from Node's built-in `os.networkInterfaces()` instead of using the vulnerable `ip` package.

## Notes

- `npm install` completed with `0 vulnerabilities`.
